### PR TITLE
Adapt to phpcpd 6.x

### DIFF
--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -1,9 +1,10 @@
 name: Code Quality Diagnostics
 
-env:
-  PHPCQ_DIRECTORY: ./phpcq-runner
-
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build:
@@ -55,3 +56,10 @@ jobs:
 
       - name: Run tests
         run: ./vendor/bin/phpcq run -o github-action -o default
+
+      - name: Upload build directory to artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ success() }} || ${{ failure() }}
+        with:
+          name: phpcq-builds
+          path: .phpcq/build/

--- a/phpcq-plugin.json
+++ b/phpcq-plugin.json
@@ -10,7 +10,7 @@
     },
     "tool": {
       "phpcpd": {
-        "constraints": "^3.0 || ^4.0 || ^5.0",
+        "constraints": "^6.0",
         "sources": [
           {
             "type": "github",

--- a/src/phpcpd.php
+++ b/src/phpcpd.php
@@ -35,17 +35,12 @@ return new class implements DiagnosticsPluginInterface {
     {
         $configOptionsBuilder->supportDirectories();
         $configOptionsBuilder
-            ->describeStringListOption('names', 'A list of file names to check.')
+            ->describeStringListOption('suffix', 'A list of file name suffixes to include.')
             ->isRequired()
-            ->withDefaultValue(['*.php']);
+            ->withDefaultValue(['.php']);
 
         $configOptionsBuilder
-            ->describeStringListOption('names_exclude', 'A list of file names to exclude.');
-
-        $configOptionsBuilder->describeStringListOption(
-            'regexps_exclude',
-            'A list of paths regexps to exclude (example: "#var/.*_tmp#")'
-        );
+            ->describeStringListOption('exclude', 'A list of path names to exclude.');
 
         $configOptionsBuilder
             ->describeIntOption('min_lines', 'Minimum number of identical lines.')
@@ -97,18 +92,22 @@ return new class implements DiagnosticsPluginInterface {
             $logFile = $environment->getUniqueTempFile($this, 'pmd-cpd.xml')
         ];
 
-        if ($config->has('names')) {
-            $args[] = '--names=' . implode(',', $config->getStringList('names'));
+        if ($config->has('suffix')) {
+            foreach ($config->getStringList('suffix') as $suffix) {
+                $args[] = '--suffix';
+                $args[] = $suffix;
+            }
         }
-        if ($config->has('names_exclude')) {
-            $args[] = '--names-exclude=' . implode(',', $config->getStringList('names_exclude'));
+        if ($config->has('exclude')) {
+            foreach ($config->getStringList('exclude') as $exclude) {
+                $args[] = '--exclude ' . $exclude;
+            }
         }
-        if ($config->has('regexps_exclude')) {
-            $args[] = '--regexps-exclude';
-            $args[] = implode(',', $config->getStringList('regexps_exclude'));
-        }
-        $args[] = '--min-lines=' . (string) $config->getInt('min_lines');
-        $args[] = '--min-tokens=' . (string) $config->getInt('min_tokens');
+
+        $args[] = '--min-lines';
+        $args[] = (string) $config->getInt('min_lines');
+        $args[] = '--min-tokens';
+        $args[] = (string) $config->getInt('min_tokens');
 
         if ($config->getBool('fuzzy')) {
             $args[] = '--fuzzy';


### PR DESCRIPTION
This includes:
- Rename option `names` to `suffix`.
- Rename option `names_exclude` to `exclude`
  (as it only applies to paths in 6.x).
- Remove option `regexps_exclude`.